### PR TITLE
Some refactors to main.c

### DIFF
--- a/main.c
+++ b/main.c
@@ -198,6 +198,24 @@ static void printhelp()
     }
 }
 
+static void tryfile(const char *name)
+{
+    FILE *fp;
+#ifdef _MSC_VER
+    errno_t err = fopen_s(&fp, name, "rb");
+    if (err != 0) {
+#else
+    fp = fopen(name, "rb");
+    if (fp == NULL) {
+#endif
+        haderrors++;
+        return;
+    }
+    dofile(fp, name);
+    fclose(fp);
+    didparse = 1;
+}
+
 static void doparse(int argc, char **argv)
 {
     int i;
@@ -220,22 +238,7 @@ static void doparse(int argc, char **argv)
             continue;
         }
 
-        FILE *fp;
-#ifdef _MSC_VER
-        errno_t err = fopen_s(&fp, argv[i], "rb");
-        if (err != 0) {
-#else
-        fp = fopen(argv[i], "rb");
-        if (fp == NULL) {
-#endif
-            printf("Error: Cannot open %s\n", argv[i]);
-            haderrors++;
-            continue;
-        }
-
-        dofile(fp, argv[i]);
-        didparse = 1;
-        fclose(fp);
+        tryfile(argv[i]);
     }
     if (argc == 1) {
         didparse = 1;

--- a/main.c
+++ b/main.c
@@ -246,11 +246,8 @@ static void doparse(int argc, char **argv)
     }
 }
 
-int main(int argc, char **argv)
+static int ret()
 {
-    init();
-    doparse(argc, argv);
-
     if (!haderrors && didparse) {
         printf("Parse successful: %8d lines: %s\n", totlines, "<total>");
         if (ignorederrors) {
@@ -268,4 +265,11 @@ int main(int argc, char **argv)
         }
         return 1;
     }
+}
+
+int main(int argc, char **argv)
+{
+    init();
+    doparse(argc, argv);
+    return ret();
 }


### PR DESCRIPTION
I'm currently working on several features(*) I intend to PR. These refactors are meant to simplify their diffs.

(*) Features:
1. Eagerly exit / fail fast on first error found (flag +ff?)
2. Flag to disable dynamic toggling of flags from parsed code (flag +???)
3. Static build including the following APIs, supporting
3.1. Parse in-memory buffer(s).
3.2. Output to a buffer instead of stdout.

```c
// Parse an in-memory buffer
int _cdecl parse_jass(char *output, const int n_max_out_size, int *n_out_size, const char* target, const int target_size);

// Parse in-memory buffers for common.j, Blizzard.j, war3map.j
int _cdecl parse_jass_triad(char *output, const int n_max_out_size, int *n_out_size, const char* buf_common, const int size_common, const char* buf_blizz, const int size_blizz, const char* buf_script, const int size_script);

// Versatile function to parse inputs as if they were passed to latest ``pjass`` binary. (``doparse`` can be refactored to use it.)
int _cdecl parse_jass_custom_r(char *output, const int n_max_out_size, int *n_out_size, const int targets_or_opts_count, const char **targets_or_opts);

// Versatile function to parse inputs with fine-grained control over each file/buffer's flags. (This is my main use case.)
int _cdecl parse_jass_custom(char *output, const int n_max_out_size, int *n_out_size, const int targets_count, const int *targets_sizes, const char **targets, const char **flags);
```

Do let me know if you find some of these features/APIs useless or w.e.